### PR TITLE
Fixes `git gud test` output

### DIFF
--- a/gitgud/skills/level_builder.py
+++ b/gitgud/skills/level_builder.py
@@ -86,6 +86,8 @@ class BasicLevel(Level):
 
         self.goal_path = self.level_dir.joinpath('goal.txt')
 
+        self.passed_path = self.level_dir.joinpath('passed.txt')
+
         if not self.instructions_path.exists():
             self.instructions_path = self.goal_path
 


### PR DESCRIPTION
This fixes the `git gud test` output, because `self.passed_path` was not defined in BasicLevel.