### PR TITLE
Added git gud debug as a hidden command

### DIFF
--- a/gitgud/__main__.py
+++ b/gitgud/__main__.py
@@ -84,6 +84,10 @@ class GitGud:
         )
 
         self.subparsers.add_parser(
+                'debug',
+                description='Debug git-gud with necessary imports set up.'
+        )
+        self.subparsers.add_parser(
                 'status',
                 help='Print out the name of the current level',
                 description='Print out the name of the current level')
@@ -212,7 +216,8 @@ class GitGud:
             'show': self.handle_show,
             'contributors': self.handle_contrib,
             'issues': self.handle_issues,
-            'solution': self.handle_solution
+            'solution': self.handle_solution,
+            'debug': self.handle_debug
         }
 
     def is_initialized(self):
@@ -521,6 +526,19 @@ class GitGud:
     def handle_issues(self, args):
         issues_website = "https://github.com/benthayer/git-gud/issues"
         webbrowser.open_new(issues_website)
+
+    def handle_debug(self, args):
+        import readline  # noqa: F401
+        import code
+        variables = globals()
+        shell = code.InteractiveConsole(variables)
+        shell.interact(
+            banner="\n".join([
+                "You are now in the Python interpreter invoked by `git gud debug`.",  # noqa: E501
+                "Your current path is " + str(Path.cwd()),
+                "To exit, type exit()"
+            ])
+        )
 
     def parse(self):
         args, _ = self.parser.parse_known_args()


### PR DESCRIPTION
This isn't for any issue, but it might be nice to have this command in case things break, and we want to probe around.

We could test the most recently released version that's distributed by PyPI without having to search for the executable to import and test.

This might also be useful for the 1.0 release if we want the user to probe around for errors by themselves, in case there's an error that they have that we can't reproduce.

I omitted the `help` argument so that the output doesn't appear in `git gud -h`.

Note: `import readline` is necessary to support history in the console.