### PR TITLE
Added support to fetch git version

### DIFF
--- a/gitgud/operations.py
+++ b/gitgud/operations.py
@@ -4,7 +4,7 @@ import datetime as dt
 import email.utils
 from pathlib import Path
 
-from git import Repo
+from git import Repo, Git
 
 from gitgud import actor
 
@@ -66,6 +66,9 @@ class Operator():
 
     def shutoff_pager(self):
         self.repo.config_writer().set_value("core", "pager", '').release()
+
+    def git_version(self):
+        return Git(self.git_path).version_info
 
     def destroy_repo(self):
         # Clear all in installation directory


### PR DESCRIPTION
A feature added in consideration of #129 .

[`version_info`](https://gitpython.readthedocs.io/en/stable/reference.html#git.cmd.Git.version_info) returns the active version of `git` as a tuple.

This doesn't fix issue #129 , but it is certainly useful for #129 's resolution.