### PR TITLE
Added prompt counter to git gud explain

### DIFF
--- a/gitgud/skills/level_builder.py
+++ b/gitgud/skills/level_builder.py
@@ -121,12 +121,10 @@ class BasicLevel(Level):
         show_tree()
 
     def explain(self):
-        for line in self.file('explanation.txt') \
-                .read_text().strip().split('\n'):
-            if line[:3] == '>>>':
-                input('>>>')
-            else:
-                print(line.strip())
+        lines = self.file('explanation.txt').read_text().strip().split('>>>')
+        for i, line in enumerate(lines):
+            print(line.strip())
+            input('>>> ({}/{})'.format(i+1, len(lines)))
 
     def goal(self):
         self.cat_file("goal.txt")


### PR DESCRIPTION
This commit also changes the behavior so now there is a `>>>` at the end. 

It produces output like this:

```
"git gud explain" will help give you more context to the currrent level
Hit enter to read more.
>>> (1/7)
As long as you see the "
>>> (2/7)
", you are reading the explanation.
More text appears each time you hit enter, can once explanation finishes, you can type commands again.
>>> (3/7)
As you progress, "git gud" will guide you through the relevant commands in both "git" and "git gud".
>>> (4/7)
The first command we'll introduce you to is "git gud commit".
 "git gud commit" is a special command that does does three things.
  1) It creates a new file
  2) It adds that file to git
  3) It commits the new file
 Whenever git gud does something for you, it will let you know what actions/commands it is simulating.
>>> (5/7)
Now look below. Since there's no more "
>>> (6/7)
", we're back in the normal command line, and you can type in commands again.

To complete this level, commit twice using "git gud commit"
When you're done, run "git gud test" to see if you've completed this level.
>>> (7/7)
```