### PR TITLE
Ignore branch capitalization for branches created by user

### DIFF
--- a/gitgud/skills/level_builder.py
+++ b/gitgud/skills/level_builder.py
@@ -2,6 +2,7 @@ from importlib_resources import files
 
 import yaml
 
+from .parsing import branches_to_lowercase
 from .parsing import test_ancestry
 from .parsing import level_json
 from .parsing import parse_spec
@@ -150,11 +151,14 @@ class BasicLevel(Level):
 
     def _test(self):
         file_operator = operations.get_operator()
-        commits, head = parse_spec(self.file('test.spec'))
 
         # Get commit trees
-        test_tree = level_json(commits, head)
+        test_tree = level_json(*parse_spec(self.file('test.spec')))
         level_tree = file_operator.get_current_tree()
+
+        # Make all user-created branches lowecase
+        setup_tree = level_json(*parse_spec(self.file('setup.spec')))
+        branches_to_lowercase(level_tree, setup_tree, test_tree)
 
         # Get commit info
         non_merges = get_non_merges(level_tree)

--- a/gitgud/skills/parsing.py
+++ b/gitgud/skills/parsing.py
@@ -180,6 +180,29 @@ def check_commits(skill, test):
     return True
 
 
+def tree_branches_to_lowercase(tree, branches):
+    branch_dict = tree['branches']
+    for branch in list(branch_dict.keys()):
+        if branch in branches and not branch == branch.lower():
+            branch_dict[branch.lower()] = branch_dict[branch]
+            branch_dict[branch.lower()]['id'] = branch.lower()
+            del branch_dict[branch]
+
+    head = tree['HEAD']
+    if head['target'] in branches:
+        head['target'] = head['target'].lower()
+
+
+def branches_to_lowercase(level_tree, setup_tree, test_tree):
+    level_branches = set(level_tree['branches'].keys())
+    setup_branches = set(setup_tree['branches'].keys())
+    test_branches = set(test_tree['branches'].keys())
+    added_branches = (level_branches | test_branches) - setup_branches
+
+    tree_branches_to_lowercase(level_tree, added_branches)
+    tree_branches_to_lowercase(test_tree, added_branches)
+
+
 def name_from_map(level_tree, mapping):
     # Map other commits to themselves
     mapping = deepcopy(mapping)
@@ -244,18 +267,21 @@ def test_ancestry(skill, test):
 
     if not check_commits(skill, test):
         return False
+
     if not has_all_branches(skill, test):
         return False
     if not all_branches_correct(skill, test):
         return False
     if not has_no_extra_branches(skill, test):
         return False
+
     if not has_all_tags(skill, test):
         return False
     if not all_tags_correct(skill, test):
         return False
     if not has_no_extra_tags(skill, test):
         return False
+
     if not head_correct(skill, test):
         return False
 

--- a/gitgud/skills/test_parsing.py
+++ b/gitgud/skills/test_parsing.py
@@ -1,0 +1,53 @@
+from gitgud.skills.parsing import branches_to_lowercase
+from gitgud.skills import all_skills
+from gitgud.skills.testing import simulate
+
+
+def test_lowercase_level(gg):
+    level = all_skills['basics']['branching']
+    commands1 = [
+        'git checkout -b bugFix',
+        'git gud commit'
+    ]
+    commands2 = [
+        'git checkout -b bugfix',
+        'git gud commit'
+    ]
+    simulate(gg, level, commands1, run_pretest=False)
+    simulate(gg, level, commands2, run_pretest=False)
+
+
+def test_branches_to_lowercase():
+    branch = {
+        'target': 'fake_commit',
+        'id': 'UPPERBRANCH'
+    }
+
+    level_tree = {
+        'branches': {'UPPERBRANCH': branch},
+        'HEAD': {'target': 'UPPERBRANCH', 'id': 'HEAD'}
+    }
+    test_tree = {
+        'branches': {'UPPERBRANCH': branch, 'MASTER': 'string'},
+        'HEAD': {'target': 'UPPERBRANCH', 'id': 'HEAD'}
+    }
+    setup_tree = {
+        'branches': {'MASTER': 'string'},
+        'HEAD': {'target': 'MASTER', 'id': 'HEAD'}
+    }
+
+    branches_to_lowercase(level_tree, setup_tree, test_tree)
+
+    assert 'UPPERBRANCH' not in level_tree['branches']
+    assert 'upperbranch' in level_tree['branches']
+    assert level_tree['branches']['upperbranch'] is branch
+    assert level_tree['HEAD']['target'] == 'upperbranch'
+
+    assert 'UPPERBRANCH' not in test_tree['branches']
+    assert 'upperbranch' in test_tree['branches']
+    assert test_tree['branches']['upperbranch'] is branch
+    assert test_tree['HEAD']['target'] == 'upperbranch'
+
+    assert 'MASTER' in test_tree['branches']
+    assert 'MASTER' in setup_tree['branches']
+    assert setup_tree['HEAD']['target'] == 'MASTER'


### PR DESCRIPTION
This works by calculating which branches are created by the user and then setting them all to lowercase.
Fixes #139 