### PR TITLE
"git gud show-tree" explanations changed to "git gud show tree"

### DIFF
--- a/gitgud/skills/basics/_merging/explanation.txt
+++ b/gitgud/skills/basics/_merging/explanation.txt
@@ -10,7 +10,7 @@ Commit once ("git gud commit")
 Go back to master with "git checkout master"
 >>>
 Commit another time, this time on the master branch.
- Use the command "git gud show-tree" to see the commit tree. This command simulates "git log --graph --oneline --all".
+ Use the command "git gud show tree" to see the commit tree. This command simulates "git log --graph --oneline --all".
  Take a note of what it looks like now so you can compare it to what the commit tree looks like after the merge.
 >>>
 Finally, merge the branch bugFix into master with "git merge bugFix".

--- a/gitgud/skills/rampup/_detaching/explanation.txt
+++ b/gitgud/skills/rampup/_detaching/explanation.txt
@@ -13,6 +13,6 @@ Example: HEAD -> bugFix -> C1   //HEAD points to bugFix.
 >>>
 In comes the concept of detaching HEAD. Simply use "git checkout <commit_hash>" to modify HEAD so that it points to the commit instead of the branch.
 >>>
-The commit hash is a unique identifier for each commit node. Use "git gud show-tree" to see the git commit tree. The hashes look something like: "d6ba740...". Since each commit hash is unique, you only need to type the first four characters of the hash to refer to the commit. (e.g. "git checkout d6ba" will detach the HEAD onto the commit of that hash)
+The commit hash is a unique identifier for each commit node. Use "git gud show tree" to see the git commit tree. The hashes look something like: "d6ba740...". Since each commit hash is unique, you only need to type the first four characters of the hash to refer to the commit. (e.g. "git checkout d6ba" will detach the HEAD onto the commit of that hash)
 >>>
-Congratulations! You've learned how to detach HEADs in git. Try using "git gud show-tree" to see how the HEAD changes before and after a detach. Use what you've learned to move the HEAD from master to commit 4.
+Congratulations! You've learned how to detach HEADs in git. Try using "git gud show tree" to see how the HEAD changes before and after a detach. Use what you've learned to move the HEAD from master to commit 4.

--- a/gitgud/skills/rampup/_relrefs1/explanation.txt
+++ b/gitgud/skills/rampup/_relrefs1/explanation.txt
@@ -12,4 +12,4 @@ The caret specification can be stacked. That is, you can use ^^ to refer to the 
 >>>
 Likewise, the ^ specification can be used on the HEAD. Using "git checkout HEAD^" allows us to move back one commit relative to the current commit we are on. Repeatedly using this command is a convenient way to move back in time!
 >>>
-Woohoo! You've learned how to use the caret specification to refer to commit objects. Use "git gud show-tree" to see the initial state of the commit history. Now, apply what you've learned about the ^ specification to checkout commit 4. (Hint: how is commit 4 related to HEAD?)
+Woohoo! You've learned how to use the caret specification to refer to commit objects. Use "git gud show tree" to see the initial state of the commit history. Now, apply what you've learned about the ^ specification to checkout commit 4. (Hint: how is commit 4 related to HEAD?)


### PR DESCRIPTION
Only "git gud show tree" currently works