### PR TITLE
Include commits from tags in level tree

### DIFF
--- a/gitgud/util/operations.py
+++ b/gitgud/util/operations.py
@@ -368,6 +368,7 @@ class Operator():
             }
 
         for tag in repo.tags:
+            commits.add(tag.commit)
             commit_hash = tag.commit.hexsha
             tree['tags'][tag.name] = {
                 'target': commit_hash,


### PR DESCRIPTION
Some commits may only be referenced by a tag, we should still keep track of these

fixes #342 